### PR TITLE
feat: add Renovate for automated dependency updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,62 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["every weekend"],
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 5,
+  "labels": ["dependencies", "renovate"],
+  "commitMessagePrefix": "chore(deps):",
+  "commitMessageAction": "update",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 3am on monday"]
+  },
+  "packageRules": [
+    {
+      "description": "Disable node version updates",
+      "matchManagers": ["nvm", "nodenv", "mise"],
+      "matchPackageNames": ["node"],
+      "enabled": false
+    },
+    {
+      "description": "Disable bun version updates",
+      "matchPackageNames": ["bun"],
+      "enabled": false
+    },
+    {
+      "description": "Auto-merge minor and patch updates for devDependencies",
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "addLabels": ["auto-merge", "dev-dependencies"]
+    },
+    {
+      "description": "Auto-merge patch updates for dependencies",
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["patch"],
+      "automerge": true,
+      "addLabels": ["auto-merge"]
+    },
+    {
+      "description": "Manual review for major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["major-update"]
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions",
+      "automerge": true,
+      "addLabels": ["github-actions"]
+    },
+    {
+      "description": "Skip auto-merge for security updates",
+      "matchDepTypes": ["dependencies"],
+      "isVulnerabilityAlert": true,
+      "automerge": false,
+      "addLabels": ["security"]
+    }
+  ]
+}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,45 @@
+name: Renovate
+
+on:
+  workflow_dispatch:
+    inputs:
+      log_level:
+        description: 'Log level'
+        required: false
+        default: 'info'
+        type: choice
+        options:
+          - debug
+          - info
+          - warn
+          - error
+  schedule:
+    - cron: '0 18 * * 5' # Every Friday at 18:00 UTC (Saturday 3:00 JST)
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/renovate.json'
+      - '.github/workflows/renovate.yml'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v40.3.2
+        with:
+          configurationFile: .github/renovate.json
+          token: ${{ secrets.RENOVATE_TOKEN || secrets.GITHUB_TOKEN }}
+        env:
+          RENOVATE_AUTODISCOVER: 'false'
+          RENOVATE_REPOSITORIES: ${{ github.repository }}
+          LOG_LEVEL: ${{ inputs.log_level || 'info' }}


### PR DESCRIPTION
## Summary
Renovateによる依存関係の自動更新を設定しました。

## 設定内容

### スケジュール
- 毎週末に更新チェック
- 毎週月曜3時前にロックファイルメンテナンス

### 更新ルール

| 対象 | 更新タイプ | 動作 |
|-----|----------|------|
| node, bun | - | **除外** |
| devDependencies | minor, patch | 自動マージ |
| dependencies | patch | 自動マージ |
| 全て | major | 手動レビュー |
| GitHub Actions | all | 自動マージ（グループ化） |
| セキュリティ | all | 手動レビュー |

### ラベル
- `dependencies`, `renovate`: 全PR
- `auto-merge`: 自動マージ対象
- `major-update`: メジャー更新
- `security`: セキュリティ更新

## ファイル
- `.github/renovate.json` - 設定ファイル
- `.github/workflows/renovate.yml` - ワークフロー

🤖 Generated with [Claude Code](https://claude.com/claude-code)